### PR TITLE
fix csv upload such that you can upload comments

### DIFF
--- a/controllers/assignments.py
+++ b/controllers/assignments.py
@@ -427,11 +427,15 @@ def mass_grade_problem():
         cells = row.split(",")
         if len(cells) < 2:
             continue
+        
         email = cells[0]
         if cells[1]=="":
             cells[1]=0
         grade = float(cells[1])
-        comment = ""
+        if len(cells) == 2:
+            comment = ""
+        else: # should only ever be 2 or 3
+            comment = cells[-1] # comment should be the last element
         user = db(db.auth_user.email == email).select().first()
         if user == None:
             continue


### PR DESCRIPTION
If there is a two-column csv (emails and grades), it will upload emails and grades with blank comments. If there is a three-column csv (emails, grades, comments) it will upload all three.